### PR TITLE
Add Git courses and translate the presentation text.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,8 @@
 
 On the Internet, there are many tutorials/courses to learn development, except that most of them are bad because they teach you bad practices or obsolete things. That is why this list of good sources for learning development has been created.
 
-* [Go to French](https://www.learndev.info/fr)
 * [Go to English](https://www.learndev.info/en)
+
+Sur Internet, il y a beaucoup de tutoriels et de cours pour apprendre le développement, seulement la plupart d'entre eux sont mauvais parce qu'ils vous enseignent des mauvaises pratiques ou des choses obsolètes. C'est pourquoi cette liste recensant des sources fiables pour apprendre le développement a été crée.
+
+* [Go to French](https://www.learndev.info/fr)

--- a/en.md
+++ b/en.md
@@ -12,6 +12,7 @@ On the Internet, there are many tutorials/courses to learn development, except t
   - [C](#c)
   - [C++](#c-1)
   - [C#](#c-2)
+  - [Git](#git)
   - [Go](#go)
   - [Haskell](#haskell)
   - [HTML/CSS](#htmlcss)
@@ -24,7 +25,6 @@ On the Internet, there are many tutorials/courses to learn development, except t
   - [Ruby](#ruby)
   - [Rust](#rust)
   - [SQL](#sql)
-  - [Git](#git)
 - [Text editors](#text-editors)
 - [The IDEs](#the-ides)
 - [Sites to avoid](#sites-to-avoid)
@@ -58,6 +58,10 @@ On the Internet, there are many tutorials/courses to learn development, except t
 * [ASP.NET (Microsoft Doc)](https://docs.microsoft.com/en-us/aspnet/)
 * [Dot.Blog Collection (E-Naxos)](http://www.e-naxos.com/AllDotBlog.html)
 * [LINQ (Jon Skeet's coding blog)](https://codeblog.jonskeet.uk/category/edulinq/)
+
+### Git
+
+* [Official course](https://git-scm.com/book/en/v2)
 
 ### Go
 
@@ -149,10 +153,6 @@ On the Internet, there are many tutorials/courses to learn development, except t
 * [PostgreSQL Documentation](https://www.postgresql.org/docs/10/static/index.html) *Recommended database*
 * [MySQL/MariaDB Documentation](https://dev.mysql.com/doc/refman/8.0/en/)
 * [SQLite Documentation](https://sqlite.org/docs.html)
-
-### Git
-
-* [Official course](https://git-scm.com/book/en/v2)
 
 ## Text editors
 

--- a/en.md
+++ b/en.md
@@ -24,6 +24,7 @@ On the Internet, there are many tutorials/courses to learn development, except t
   - [Ruby](#ruby)
   - [Rust](#rust)
   - [SQL](#sql)
+  - [Git](#git)
 - [Text editors](#text-editors)
 - [The IDEs](#the-ides)
 - [Sites to avoid](#sites-to-avoid)
@@ -148,6 +149,10 @@ On the Internet, there are many tutorials/courses to learn development, except t
 * [PostgreSQL Documentation](https://www.postgresql.org/docs/10/static/index.html) *Recommended database*
 * [MySQL/MariaDB Documentation](https://dev.mysql.com/doc/refman/8.0/en/)
 * [SQLite Documentation](https://sqlite.org/docs.html)
+
+### Git
+
+* [Official course](https://git-scm.com/book/en/v2)
 
 ## Text editors
 

--- a/fr.md
+++ b/fr.md
@@ -12,6 +12,7 @@ Sur Internet, il existe de nombreux tutoriels/cours pour apprendre le développe
   - [C](#c)
   - [C++](#c-1)
   - [C#](#c-2)
+  - [Git](#git)
   - [Go](#go)
   - [Haskell](#haskell)
   - [HTML/CSS](#htmlcss)
@@ -25,7 +26,6 @@ Sur Internet, il existe de nombreux tutoriels/cours pour apprendre le développe
   - [Rust](#rust)
   - [Sécurité](#sécurité)
   - [SQL](#sql)
-  - [Git](#git)
 - [Éditeurs génériques](#%C3%A9diteurs-g%C3%A9n%C3%A9riques)
 - [Les IDE](#les-ide)
 - [Les sites à éviter](#les-sites-%C3%A0-%C3%A9viter)
@@ -90,6 +90,16 @@ Malheureusement, il n'y a pas de bon tutoriel/cours en français pour ce langage
 * [ASP.NET (Doc Microsoft)](https://docs.microsoft.com/en-us/aspnet/)
 * [Dot.Blog Collection (E-naxos)](http://www.e-naxos.com/AllDotBlog.html)
 * [LINQ (Jon Skeet's coding blog)](https://codeblog.jonskeet.uk/category/edulinq/)
+
+### Git
+
+#### ![FR](https://raw.githubusercontent.com/learndev-info/awesome-learning-dev-fr/master/medias/franceflag.png)
+
+* [Traduction française du cours officiel](https://git-scm.com/book/fr/v2)
+
+#### ![EN](https://raw.githubusercontent.com/learndev-info/awesome-learning-dev-fr/master/medias/greatbritainflag.png)
+
+* [Cours officiel](https://git-scm.com/book/en/v2)
 
 ### Go
 
@@ -260,16 +270,6 @@ Malheureusement, il n'y a pas de bon tutoriel/cours en français pour ce langage
 * [Documentation PostgreSQL](https://www.postgresql.org/docs/10/static/index.html) *Base de données recommandée*
 * [Documentation MySQL/MariaDB](https://dev.mysql.com/doc/refman/8.0/en/)
 * [Documentation SQLite](https://sqlite.org/docs.html)
-
-### Git
-
-#### ![FR](https://raw.githubusercontent.com/learndev-info/awesome-learning-dev-fr/master/medias/franceflag.png)
-
-* [Traduction française du cours officiel](https://git-scm.com/book/fr/v2)
-
-#### ![EN](https://raw.githubusercontent.com/learndev-info/awesome-learning-dev-fr/master/medias/greatbritainflag.png)
-
-* [Cours officiel](https://git-scm.com/book/en/v2)
 
 ## Éditeurs génériques
 

--- a/fr.md
+++ b/fr.md
@@ -25,6 +25,7 @@ Sur Internet, il existe de nombreux tutoriels/cours pour apprendre le développe
   - [Rust](#rust)
   - [Sécurité](#sécurité)
   - [SQL](#sql)
+  - [Git](#git)
 - [Éditeurs génériques](#%C3%A9diteurs-g%C3%A9n%C3%A9riques)
 - [Les IDE](#les-ide)
 - [Les sites à éviter](#les-sites-%C3%A0-%C3%A9viter)
@@ -259,6 +260,16 @@ Malheureusement, il n'y a pas de bon tutoriel/cours en français pour ce langage
 * [Documentation PostgreSQL](https://www.postgresql.org/docs/10/static/index.html) *Base de données recommandée*
 * [Documentation MySQL/MariaDB](https://dev.mysql.com/doc/refman/8.0/en/)
 * [Documentation SQLite](https://sqlite.org/docs.html)
+
+### Git
+
+#### ![FR](https://raw.githubusercontent.com/learndev-info/awesome-learning-dev-fr/master/medias/franceflag.png)
+
+* [Traduction française du cours officiel](https://git-scm.com/book/fr/v2)
+
+#### ![EN](https://raw.githubusercontent.com/learndev-info/awesome-learning-dev-fr/master/medias/greatbritainflag.png)
+
+* [Cours officiel](https://git-scm.com/book/en/v2)
 
 ## Éditeurs génériques
 


### PR DESCRIPTION
This pull request add official Git courses in English and French for the French website and the official English Git course for the English website.
These courses do not appear at the top of search engines, but are for me good courses, because I understood the main concepts of Git with those ones.

I also translated the text of the readme in french.

(Sorry for any English mistakes).