### PR TITLE
Update fr.md

### DIFF
--- a/fr.md
+++ b/fr.md
@@ -363,7 +363,7 @@ Malheureusement, il n'y a pas de bon tutoriel/cours en français pour ce langage
 Ces sites donnent de nombreuses informations fausses et/ou obsolètes et ne devraient pas être utilisés
 
 * OpenClassrooms
-* W3Schools *(Si vous vous demandez pourquoi ce site est listé ici, [voici la réponse](http://web.archive.org/web/20190401114917/https://xela.isfucking.cool/blog/fr/why-is-w3schools-bad))*
+* W3Schools
 * W3Resource
 * La chaîne youtube de PrimFX
 


### PR DESCRIPTION
Suppression du lien mort pour l'explication de W3School. Le lien original du site et le lien de WayBack Machine étant tous les deux HS (404 sur le site original et WBM : *web.archive.org n'a envoyé aucune donnée*.), il serait mieux de le supprimer (ou de retrouver l'article / le poster ailleurs).