### PR TITLE
Add further informations about deprecated sources

### DIFF
--- a/fr.md
+++ b/fr.md
@@ -370,7 +370,7 @@ Ces sites donnent de nombreuses informations fausses et/ou obsolètes et ne devr
 - La chaîne youtube de PrimFx
 
 ## Sources à compléter
-- La chaîne youtube de Graven est à compléter avec d'autres cours à côté
+- La chaîne youtube de `Graven - Développement` ne fait pas office de cours complet mais sert seulement à introduire des notions. Elle doit donc être accompagnée d'un apprentissage plus poussé.
 
 ## Liens utiles
 

--- a/fr.md
+++ b/fr.md
@@ -367,8 +367,7 @@ Ces sites donnent de nombreuses informations fausses et/ou obsolètes et ne devr
 - OpenClassrooms
 - W3Schools
 - W3Resource
-- La chaîne youtube de PrimFX
-- La chaîne youtube de Graven - Développement
+- La chaîne youtube de PrimFx
 
 ## Liens utiles
 

--- a/fr.md
+++ b/fr.md
@@ -369,6 +369,9 @@ Ces sites donnent de nombreuses informations fausses et/ou obsolètes et ne devr
 - W3Resource
 - La chaîne youtube de PrimFx
 
+## Sources à compléter
+- La chaîne youtube de Graven est à compléter avec d'autres cours à côté
+
 ## Liens utiles
 
 Ces sites sont une bonne source d'information pour de nombreux langages de programmation.


### PR DESCRIPTION
Move `Graven - Développement` from `Deprecated` section to the newly created `Sources à compléter`