### PR TITLE
Update fr.md

### DIFF
--- a/fr.md
+++ b/fr.md
@@ -191,7 +191,6 @@ Malheureusement, il n'y a pas (encore) de bon tutoriel/cours en français pour c
 
 #### ![FR](https://raw.githubusercontent.com/learndev-info/awesome-learning-dev-fr/master/medias/franceflag.png)
 
-- [Tutoriel/Cours (JM Doudoux)](https://www.jmdoudoux.fr/java/dej/indexavecframes.htm)
 - [Cours (Alexandre Mesle)](https://enseignement.alexandre-mesle.com/java/) (contient également bon nombre d'exercices)
 - [Formation (KOOR)](http://koor.fr/Java/Tutorial/Index.wp)
 - [Formation (KOOR Youtube)](https://www.youtube.com/watch?v=pXaaacSkPqc&list=PLBNheBxhHLQxfJhoz193-dRwvc2rl8AOW) ![Vidéo](https://raw.githubusercontent.com/learndev-info/awesome-learning-dev-fr/master/medias/videocamera.png?v=1.0.1 "Vidéo")
@@ -393,6 +392,7 @@ Ces sites donnent de nombreuses informations fausses et/ou obsolètes et ne devr
 - W3Schools
 - W3Resource
 - La chaîne youtube de PrimFX
+- JMDouDoux
 
 ## Liens utiles
 

--- a/fr.md
+++ b/fr.md
@@ -393,7 +393,6 @@ Ces sites donnent de nombreuses informations fausses et/ou obsolètes et ne devr
 - W3Schools
 - W3Resource
 - La chaîne youtube de PrimFX
-- La chaîne youtube de Graven - Développement
 
 ## Liens utiles
 


### PR DESCRIPTION
Removed the `Graven - Développement` channel from the French avoid list.

Effectively, the series that could, in the past, be problematic with bad practices... are now, for the most, marked as deprecated. I'll take the example of the old Web series : this series has, 1 month ago, placed into a playlist that explicitly marks the content as deprecated.
For the other mistakes on the series, even the websites you give as references can contains content that is not recommended nowadays, but it doesn't make the courses bad.

Furthermore, I want to note that the pull request that added this line to the file has been made after a conflict between the author of the pull request and the concerned YouTuber. 

So, can you consider this pull request and do not reject it with only one approbation.