### PR TITLE
fix(fr): remove graven from the avoid list

### DIFF
--- a/fr.md
+++ b/fr.md
@@ -393,7 +393,6 @@ Ces sites donnent de nombreuses informations fausses et/ou obsolètes et ne devr
 - W3Schools
 - W3Resource
 - La chaîne youtube de PrimFX
-- La chaîne youtube de Graven - Développement
 
 ## Liens utiles
 


### PR DESCRIPTION
After `Graven - Development` was added to the list of resources to avoid, the YouTuber in question made efforts to correct this. Indeed, its web series which was the main reason for adding Graven to the list has been put in "old". Also, Graven also started advising beginners to search the documentation themselves when they encounter a problem. For all these reasons, I think it's time to remove Graven from the list.