### PR TITLE
Ajout de la traduction française de javascript.info

### DIFF
--- a/fr.md
+++ b/fr.md
@@ -210,6 +210,7 @@ Malheureusement, il n'y a pas (encore) de bon tutoriel/cours en français pour c
 #### ![FR](https://raw.githubusercontent.com/learndev-info/awesome-learning-dev-fr/master/medias/franceflag.png)
 
 - [Guide complet (Pierre Giraud)](https://www.pierre-giraud.com/javascript-apprendre-coder-cours/)
+- [Tutoriel/Cours (JavaScript.info)](https://fr.javascript.info/)
 - [Formation Node.js (Louistiti)](https://www.youtube.com/playlist?list=PL4NbGBfr4aJk5ATFWA-8UkvL8LbHqpS-v) ![Vidéo](https://raw.githubusercontent.com/learndev-info/awesome-learning-dev-fr/master/medias/videocamera.png?v=1.0.1 "Vidéo") ![En cours](https://raw.githubusercontent.com/learndev-info/awesome-learning-dev-fr/master/medias/wip.png?v=1.0.0 "En cours")
 - ["Devenir un développeur Node.js" (Thomas Gentilhomme)](https://docs.google.com/document/d/1JHgmEFkc8Py4XSuCB8_DQ5FFEJoogyeninFK6ucTd4o/edit?usp=sharing)
 

--- a/fr.md
+++ b/fr.md
@@ -210,7 +210,7 @@ Malheureusement, il n'y a pas (encore) de bon tutoriel/cours en français pour c
 #### ![FR](https://raw.githubusercontent.com/learndev-info/awesome-learning-dev-fr/master/medias/franceflag.png)
 
 - [Guide complet (Pierre Giraud)](https://www.pierre-giraud.com/javascript-apprendre-coder-cours/)
-- [Tutoriel/Cours (JavaScript.info)](https://fr.javascript.info/)
+- [Tutoriel/Cours (JavaScript.info)](https://fr.javascript.info/) ![En cours](https://raw.githubusercontent.com/learndev-info/awesome-learning-dev-fr/master/medias/wip.png?v=1.0.0 "En cours")
 - [Formation Node.js (Louistiti)](https://www.youtube.com/playlist?list=PL4NbGBfr4aJk5ATFWA-8UkvL8LbHqpS-v) ![Vidéo](https://raw.githubusercontent.com/learndev-info/awesome-learning-dev-fr/master/medias/videocamera.png?v=1.0.1 "Vidéo") ![En cours](https://raw.githubusercontent.com/learndev-info/awesome-learning-dev-fr/master/medias/wip.png?v=1.0.0 "En cours")
 - ["Devenir un développeur Node.js" (Thomas Gentilhomme)](https://docs.google.com/document/d/1JHgmEFkc8Py4XSuCB8_DQ5FFEJoogyeninFK6ucTd4o/edit?usp=sharing)
 


### PR DESCRIPTION
Proposition d'ajout de la [traduction en français](https://fr.javascript.info) de [javascript.info](https://javascript.info)
Seuls quelques chapitres n'ont pas finis d'être entièrement traduits
Avancement sur [la page translate](https://javascript.info/translate)